### PR TITLE
[Fix] no jquery avaible on console_assets: fallback on jquery.com lib

### DIFF
--- a/src/main/webapp/usage.html
+++ b/src/main/webapp/usage.html
@@ -3,7 +3,7 @@
 <head>
     <link rel="icon" href="http://neo4j.org/favicon.ico" />
     <title>Neo4j Console</title>
-    <script src="console_assets/javascripts/jquery-1.6.4.min.js"></script>
+    <script src="http://code.jquery.com/jquery-1.6.4.min.js"></script>
 	<script type="text/javascript">
         var base=document.location.protocol+"//"+document.location.host;
 		function start() {


### PR DESCRIPTION
If we host this code on a heroku plateforme for instance, the usage.html page is not working because it can't find jquery (there is no console_assets folder in the rabbithole repository).

There are two mains options to solve it : 
- First, create a console_assets in the rabbithole repository and add the jquery
- Second, link to the jquery
