### PR TITLE
Synchronize on sessions field during cleanSessions() to avoid

### DIFF
--- a/src/main/java/org/neo4j/community/console/SessionService.java
+++ b/src/main/java/org/neo4j/community/console/SessionService.java
@@ -102,18 +102,20 @@ class SessionService {
     }
 
     public static void cleanSessions() {
-        Iterator<Map.Entry<String,Neo4jService>> it = sessions.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<String, Neo4jService> entry = it.next();
-            Neo4jService service = entry.getValue();
-            if (service !=null) {
-                try {
-                    service.stop();
-                } catch (Exception e) {
-                    // ignore
+        synchronized(sessions) {
+            Iterator<Map.Entry<String,Neo4jService>> it = sessions.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, Neo4jService> entry = it.next();
+                Neo4jService service = entry.getValue();
+                if (service !=null) {
+                    try {
+                        service.stop();
+                    } catch (Exception e) {
+                        // ignore
+                    }
                 }
+                it.remove();
             }
-            it.remove();
         }
         lastUsage.clear();
     }


### PR DESCRIPTION
ConcurrentModificationExceptions if sessions are added/removed during
cleanup.

Got an exception while playing around with gists.neo4j.org, so I toke a look at it :-)
@jexp You worked on the sessions management code just a few days ago, mind to give it a quick review?
