### PR TITLE
fixed results details not being scrollable for large details

### DIFF
--- a/src/main/webapp/stylesheets/main.css
+++ b/src/main/webapp/stylesheets/main.css
@@ -72,6 +72,10 @@ a:link, a:visited {
    display: none;
 }
 
+div#stats {
+    overflow-y: scroll;
+}
+
 pre {
   font-family: 'Bitstream Vera Sans Mono', 'DejaVu Sans Mono', 'Consolas', 'Monaco', Courier, monospace !important;
 }


### PR DESCRIPTION
Hi,

I added a scroll on the results details div, when details are becoming large, the execution plan was not scrollable : 

before : 

![Imgur](http://i.imgur.com/FBc2bp0.png)

After : 

![Imgur](http://i.imgur.com/50Do00Z.png)
