### PR TITLE
Wrap labels, property names in backticks on export

### DIFF
--- a/src/main/java/org/neo4j/community/console/CypherExportService.java
+++ b/src/main/java/org/neo4j/community/console/CypherExportService.java
@@ -71,7 +71,7 @@ class CypherExportService {
 
     private void formatLabels(StringBuilder sb, Node node) {
         for (Label label : node.getLabels()) {
-            sb.append(":").append(label.name());
+            sb.append(":`").append(label.name()).append("`");
         }
     }
 
@@ -88,7 +88,7 @@ class CypherExportService {
     }
 
     private String removeNameQuotes(String json) {
-        return json.replaceAll("\"([^\"]+)\":","$1:");
+        return json.replaceAll("\"([^\"]+)\":","`$1`:");
     }
 
     Map<String, Object> toMap(PropertyContainer pc) {


### PR DESCRIPTION
Wrap labels and property names in backticks when exporting/sharing to avoid broken setup queries.