### PR TITLE
fixes broken link to Cypher ref card

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -114,7 +114,7 @@
         <div style="float:left;padding:5px;"><h4>Video: How to use the Console efficiently</h4>
         <img id='video' src="/img/console-intro-video.png" video="http://player.vimeo.com/video/56097037" width="200" height="150" style="display:inline-block;border: 1px solid darkgrey;"/></div>
         <div style="float:left; padding:5px;"><h4>Cypher Reference Card</h4>
-        <a href="http://neo4j.org/resources/cypher" target="neo4j-console"><img id='refcard' src="/img/cypher_refcard.gif" width="200" height="150" style="display:inline-block;border: 1px solid darkgrey;"/></a></div>
+        <a href="http://neo4j.com/docs/cypher-refcard/current/" target="neo4j-console"><img id='refcard' src="/img/cypher_refcard.gif" width="200" height="150" style="display:inline-block;border: 1px solid darkgrey;"/></a></div>
         <div style="clear:both;"></div>
         <p>The console is hosted on Heroku at <a href="http://console.neo4j.org">http://console.neo4j.org</a> the source
         code is available on <a target="neo4j-console" href="http://github.com/neo4j-contrib/rabbithole">GitHub</a>.</p>


### PR DESCRIPTION
Link http://neo4j.org/resources/cypher replaced with http://neo4j.com/docs/cypher-refcard/current/
